### PR TITLE
BUG:on_connect bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -20,16 +20,20 @@ class Cognibot(discord.Bot):
         self.command_usage = {}
         self.uptime_start = datetime.now()
         self.error_log = deque(maxlen=100)
+        self.debug = env_vars["DEBUG"]
 
     async def on_ready(self):
         app_logger.info(f"{self.user} is ready and online!")
         self.monitor_health.start()
         self.db.init_db()
+        if self.debug:
+            print(f"{self.user} is ready for development!")
 
     async def on_disconnect(self):
         app_logger.warning("Bot disconnected from Discord")
 
     async def on_connect(self):
+        await super().on_connect()
         app_logger.info("Bot reconnected to Discord")
 
     async def on_resumed(self):

--- a/utils/env.py
+++ b/utils/env.py
@@ -51,4 +51,5 @@ env_vars = {
     # "db_host": os.environ.get("DB_HOST"),
     # "db_url": os.environ.get("DATABASE_URL"),
     "db_type": "sqlite",
+    "DEBUG": os.environ.get("DEBUG", False),
 }


### PR DESCRIPTION
## Description

The on_connect method was improperly overriding the base on_connect so the slash commands were not being loaded. Corrected the on_connect method and added a new env variable for debug mode to add the print statement back in the terminal for development.

I did troubleshoot setting up on a new environment for the "discord" error and I did receive that specific error after installing dependencies but it was still due to my IDE using the wrong python environment.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Potential Issues

I have noticed that in powershell and some windows environments 1 or two tests will regularly fail. Currently the test_claude test fails in a powershell environment.
